### PR TITLE
ログアウト時のマイページ遷移エラーを修正

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,7 +22,7 @@
         <div class="field p-form-board__contents__item">
           <%= f.label :password %><br />
           <%= f.password_field :password, autocomplete: "new-password", class: "p-form-board__contents__item__text" %><br />
-          <small>パスワードは8文字以上で入力してください</small>
+          <small>英字と数字の両方を含めて8文字以上で入力してください</small>
         </div>
 
         <% # パスワード(確認用) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,7 +61,7 @@
       </div>
       <span>
         <%# フォローボタン %>
-        <% if current_user != @user %>
+        <% if user_signed_in? && current_user != @user %>
           <% if @user.followed_by?(current_user) %>
             <span class="c-btn__following">
               <P><%= link_to "フォロー中", user_relationships_path(@user.id), method: :delete, class:"c-btn__following--normal" %></p>


### PR DESCRIPTION
# 何か
- ログインしていない状態での、マイページ遷移時のエラーを解消
  - ログアウト状態では、フォローボタンが表示されないように設定

![ログイン前](https://user-images.githubusercontent.com/61915228/104086123-5933b680-5298-11eb-967e-a2ecd2001502.gif)


- ユーザ新規登録画面のパスワードの案内メッセージを変更

<img width="1258" alt="ユーザ新規登録画面" src="https://user-images.githubusercontent.com/61915228/104086127-68b2ff80-5298-11eb-9350-caa0d342ab69.png">

# 変更・追加
- app/views/devise/registrations/new.html.erb
- app/views/users/show.html.erb
