### PR TITLE
ユーザー一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/object/component/_button.scss
+++ b/app/assets/stylesheets/object/component/_button.scss
@@ -48,6 +48,46 @@
   }
 }
 
+//ページネーションボタン
+.c-paginate__btn {
+  width: 100%;
+  margin: 50px auto;
+  font-size: 17px;
+  outline: none;
+
+  a {
+    text-decoration: none;
+    color: $sub-text-color;
+  }
+
+  & .page {
+    color: $sub-text-color;
+    background-color: $text-color2;
+    display: inline-block;
+    width: 33px;
+    margin: 0 5px;
+    font-size: 17px;
+    border: 2px solid $sub-text-color;
+
+    &.current {
+      background-color: $sub-text-color;
+      color: $text-color2;
+      display: inline-block;
+      width: 33px;
+      margin: 0 5px;
+      border: 2px solid $sub-text-color;
+    }
+  }
+
+  & .next {
+    margin-right: 5px;
+  }
+
+  & .prev {
+    margin-left: 5px;
+  }
+}
+
 //sp版ユーザー検索ボタン
 .c-button__users__search {
   display: none;

--- a/app/assets/stylesheets/object/project/_users.scss
+++ b/app/assets/stylesheets/object/project/_users.scss
@@ -119,12 +119,14 @@
       border-radius: 5px;
       width: 167px;
       height: 28px;
+      outline: none;
     }
     &__number {
       width: 52px;
       height: 28px;
       border: 0.5px solid #707070;
       border-radius: 5px;
+      outline: none;
     }
 
     span {

--- a/app/assets/stylesheets/object/project/_users.scss
+++ b/app/assets/stylesheets/object/project/_users.scss
@@ -151,12 +151,16 @@
 
   &__list {
     width: 802px;
-    background-color: $main-color;
-    padding: 15px;
 
     @include sp-layout {
       width: 100%;
     }
+
+    &__box {
+      background-color: $main-color;
+      padding: 15px;
+    }
+
     &.close {
       display: none;
     }

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -121,8 +121,8 @@
 <% end %>
 </div>
 
-<div class="p-users__list">
-  <ul>
+<div>
+  <ul class="p-users__list">
   <% @users.each do |user| %>
     <%= link_to user_path(user.id) do %>
       <li class="p-users__list__item">
@@ -192,9 +192,9 @@
       </li>
     <% end %>
   <% end %>
-  </ol>
+  </ul>
+  <button class="c-paginate__btn"><%= paginate @users %></button>
 </div>
-<%= paginate @users %>
 <button class="c-button__users__search"><i class="fas fa-search"></i></button>
 </section>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -121,8 +121,8 @@
 <% end %>
 </div>
 
-<div>
-  <ul class="p-users__list">
+<div class="p-users__list">
+  <ul class="p-users__list__box">
   <% @users.each do |user| %>
     <%= link_to user_path(user.id) do %>
       <li class="p-users__list__item">


### PR DESCRIPTION
#何をしたか  
ユーザー一覧ページ の実装
※ページネーション
※検索boxの余白(paddingではなくoutline:noneにて実装)  
#変更・追加  
・app/views/users/index.html.erb  
・app/assets/stylesheets/object/component/_button.scss  
・app/assets/stylesheets/object/project/_users.scss  
ご確認をよろしくお願いします！

![image](https://user-images.githubusercontent.com/68384885/104087360-8ab17f80-52a2-11eb-9215-0d1643bc9f36.png)
![image](https://user-images.githubusercontent.com/68384885/104087374-93a25100-52a2-11eb-9e84-1951d5c44044.png)
![image](https://user-images.githubusercontent.com/68384885/104087377-9735d800-52a2-11eb-91ed-924b1efbe029.png)
![image](https://user-images.githubusercontent.com/68384885/104087388-9ef57c80-52a2-11eb-8063-3d5e23777572.png)

