### PR TITLE
背景のエラー

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bin/rails db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,14 +20,14 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
#何か
 (1)https://qiita.com/___xxx_/items/fa15f358beba2b9389da 
 背景画像が表示されない状態を解消したいので、上記のQiitaを参考に、 
 production.rbのconfig.assets.compile をfalseから trueに変更
 
 (2)Procfileの作成
作成することで、 Herokuにデプロイするたびにマイグレーションが自動化されます。
 
#変更・追加
(1)config/environments/production.rb
(2)Procfile(新規作成)